### PR TITLE
Fix user registration failing due to new `user_save()` return value.

### DIFF
--- a/logintoboggan.module
+++ b/logintoboggan.module
@@ -442,7 +442,7 @@ function logintoboggan_user_register_submit($form, &$form_state) {
   // Populate $edit with the properties of $account, which have been edited on
   // this form by taking over all values, which appear in the form values too.
   $edit = array_intersect_key((array) $account, $form_state['values']);
-  $result = user_save($account, $edit);
+  $result = user_save($account);
 
   // Terminate if an error occurred during user_save().
   if (!$result) {

--- a/logintoboggan.module
+++ b/logintoboggan.module
@@ -442,10 +442,10 @@ function logintoboggan_user_register_submit($form, &$form_state) {
   // Populate $edit with the properties of $account, which have been edited on
   // this form by taking over all values, which appear in the form values too.
   $edit = array_intersect_key((array) $account, $form_state['values']);
-  $account = user_save($account, $edit);
+  $result = user_save($account, $edit);
 
   // Terminate if an error occurred during user_save().
-  if (!$account) {
+  if (!$result) {
     backdrop_set_message(t("Error saving user account."), 'error');
     $form_state['redirect'] = '';
     return;


### PR DESCRIPTION
The `user_save()` function no longer returns the `$account` object so we can't set the return value to it as doing so causes subsequent code logic to fail because the return value is `FALSE` on failure or the `SAVED_NEW` or `SAVED_UPDATED` constants on success.

Fixes #8